### PR TITLE
fix(ui): transparent fixed header and remove inner page scroll

### DIFF
--- a/app/(user)/page.tsx
+++ b/app/(user)/page.tsx
@@ -14,7 +14,7 @@ export default async function Home() {
     await fetchSanityData();
 
   return (
-    <div className="bg-background text-foreground min-h-screen snap-y snap-mandatory overflow-y-scroll overflow-x-hidden z-0 scroll-smooth scrollbar-thin scrollbar-track-slate-900/20 scrollbar-thumb-blue-500/20 hover:scrollbar-thumb-blue-500/40">
+    <div className="bg-background text-foreground min-h-screen overflow-x-hidden z-0 scroll-smooth">
       <Header socials={socials} />
 
       <section id="hero" className="snap-start h-screen">

--- a/app/(user)/projects/[slug]/page.tsx
+++ b/app/(user)/projects/[slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function ProjectPage({ params }: Props) {
   }
 
   return (
-    <main className="bg-background text-foreground min-h-screen overflow-y-scroll overflow-x-hidden scroll-smooth scrollbar-thin scrollbar-track-slate-900/20 scrollbar-thumb-blue-500/20 hover:scrollbar-thumb-blue-500/40">
+    <main className="bg-background text-foreground min-h-screen overflow-x-hidden scroll-smooth">
       <StructuredData project={project} slug={slug} />
 
       <Header socials={socials} />

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -10,7 +10,7 @@ type HeaderProps = {
 
 function Header({ socials }: HeaderProps) {
   return (
-    <header className="sticky top-0 p-5 flex items-start justify-between max-w-7xl mx-auto z-20 xl:items-center">
+    <header className="fixed inset-x-0 top-0 z-50 mx-auto flex max-w-7xl items-start justify-between bg-transparent p-5 xl:items-center">
       <motion.div
         initial={{ x: -500, opacity: 0, scale: 0.5 }}
         animate={{ x: 0, opacity: 1, scale: 1 }}


### PR DESCRIPTION
Closes https://github.com/usamanadeemdeveloper/portfolio/issues/5

### What changed
- Header is **fixed** and **transparent** so the hero rings show through to the top instead of a sticky strip that looked like a solid band.
- Removed **`overflow-y-scroll`** (and wrapper scrollbar styling) on the **home** and **project** shells so the **page** scrolls normally—no extra scrollbar tied to the header row.

### How to verify
1. Home: circles read through behind the top nav.
2. No thin “inner” scrollbar aligned with the header row.
3. Social icons and **Get in touch** still open / navigate correctly.